### PR TITLE
Add support for using /dev/urandom as a randomness source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
-CC=gcc -O3 -Wall -Wextra -std=c99 -Wno-deprecated-declarations
+CC=clang
 
-CPPFLAGS=
-LDFLAGS=-lcrypto
-
-# On Mac OS X, the system OpenSSL is too old.  
-# Install your own more recent version and point to it.  
-# If you have installed OpenSSL via brew, you can use the following two lines.
-CPPFLAGS=-I/usr/local/opt/openssl/include
-LDFLAGS=-L/usr/local/opt/openssl/lib -lcrypto
+CCFLAGS=-O3 -Wall -Wextra -std=c99 -DRLWE_RANDOMNESS_USE_DEV_URANDOM
+LDFLAGS=
 
 all:
-	$(CC) $(CPPFLAGS) -Wno-unused-function -c fft.c
-	$(CC) $(CPPFLAGS) -Wno-unused-function -c rlwe.c
-	$(CC) $(CPPFLAGS) -Wno-unused-function -c rlwe_kex.c
-	$(CC) $(CPPFLAGS) -Wno-unused-function -Wno-unused-parameter -c rlwe_rand.c
-	$(CC) $(CPPFLAGS) -o rlwe_main -lcrypto rlwe_main.c fft.o rlwe.o rlwe_kex.o rlwe_rand.o $(LDFLAGS)
-	$(CC) $(CPPFLAGS) -o rlwe_benchmark -lcrypto rlwe_benchmark.c fft.o rlwe.o rlwe_kex.o rlwe_rand.o $(LDFLAGS)
+	$(CC) $(CCFLAGS) -Wno-unused-function -c fft.c
+	$(CC) $(CCFLAGS) -Wno-unused-function -c rlwe.c
+	$(CC) $(CCFLAGS) -Wno-unused-function -c rlwe_kex.c
+	$(CC) $(CCFLAGS) -Wno-unused-function -c rlwe_rand.c
+	$(CC) $(CCFLAGS) -o rlwe_main -lcrypto rlwe_main.c fft.o rlwe.o rlwe_kex.o rlwe_rand.o $(LDFLAGS)
+	$(CC) $(CCFLAGS) -o rlwe_benchmark -lcrypto rlwe_benchmark.c fft.o rlwe.o rlwe_kex.o rlwe_rand.o $(LDFLAGS)
 
 clean:
 	rm fft.o rlwe.o rlwe_kex.o rlwe_rand.o rlwe_main rlwe_benchmark

--- a/rlwe_benchmark.c
+++ b/rlwe_benchmark.c
@@ -73,7 +73,7 @@ int main() {
 	}
 
 	RAND_CTX rand_ctx;
-	if (!RAND_CTX_init(&rand_ctx)) {
+	if (!RAND_CHOICE_init(&rand_ctx)) {
 		printf("Randomness allocation error.");
 		return -1;
 	}
@@ -105,7 +105,7 @@ int main() {
 	FFT_CTX_clear(&ctx);
 	FFT_CTX_free(&ctx);
 
-	RAND_CTX_cleanup(&rand_ctx);
+	RAND_CHOICE_cleanup(&rand_ctx);
 
 	return 0;
 

--- a/rlwe_kex.c
+++ b/rlwe_kex.c
@@ -22,7 +22,7 @@ int rlwe_kex_generate_keypair(const uint32_t *a, uint32_t s[1024], uint32_t b[10
 	int ret;
 	uint32_t e[1024];
 	RAND_CTX rand_ctx;
-	ret = RAND_CTX_init(&rand_ctx);
+	ret = RAND_CHOICE_init(&rand_ctx);
 	if (!ret) {
 		return ret;
 	}
@@ -35,7 +35,7 @@ int rlwe_kex_generate_keypair(const uint32_t *a, uint32_t s[1024], uint32_t b[10
 #endif
 	rlwe_key_gen(b, a, s, e, ctx);
 	rlwe_memset_volatile(e, 0, 1024 * sizeof(uint32_t));
-	RAND_CTX_cleanup(&rand_ctx);
+	RAND_CHOICE_cleanup(&rand_ctx);
 	return ret;
 }
 
@@ -56,7 +56,7 @@ int rlwe_kex_compute_key_bob(const uint32_t b[1024], const uint32_t s[1024], uin
 	uint32_t v[1024];
 	uint32_t eprimeprime[1024];
 	RAND_CTX rand_ctx;
-	ret = RAND_CTX_init(&rand_ctx);
+	ret = RAND_CHOICE_init(&rand_ctx);
 	if (!ret) {
 		return ret;
 	}
@@ -75,7 +75,7 @@ int rlwe_kex_compute_key_bob(const uint32_t b[1024], const uint32_t s[1024], uin
 #endif
 	rlwe_memset_volatile(v, 0, 1024 * sizeof(uint32_t));
 	rlwe_memset_volatile(eprimeprime, 0, 1024 * sizeof(uint32_t));
-	RAND_CTX_cleanup(&rand_ctx);
+	RAND_CHOICE_cleanup(&rand_ctx);
 	return ret;
 }
 

--- a/rlwe_rand.c
+++ b/rlwe_rand.c
@@ -6,8 +6,10 @@
 #include "rlwe_rand_openssl_rc4.c"
 #elif defined(RLWE_RANDOMNESS_USE_OPENSSL_RAND)
 #include "rlwe_rand_openssl_rand.c"
-#elif defined(RLWE_RANDOMNESS_USE_C_RANDOM_INSECURE)
-#include "rlwe_rand_c.c"
+#elif defined(RLWE_RANDOMNESS_USE_DEV_URANDOM)
+#include "rlwe_rand_dev_urandom.c"
+#elif defined(RLWE_RANDOMNESS_USE_INSECURE_LIBC)
+#include "rlwe_rand_libc.c"
 #else
 #error "No randomness generation algorithm defined."
 #endif

--- a/rlwe_rand.h
+++ b/rlwe_rand.h
@@ -4,7 +4,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#define RLWE_RANDOMNESS_USE_OPENSSL_AES
+#define RLWE_RANDOMNESS_USE_DEV_RANDOM
+// #define RLWE_RANDOMNESS_USE_OPENSSL_AES
 // #define RLWE_RANDOMNESS_USE_OPENSSL_RC4
 // #define RLWE_RANDOMNESS_USE_OPENSSL_RAND
 // #define RLWE_RANDOMNESS_USE_C_RANDOM_INSECURE
@@ -21,7 +22,7 @@
 #define RAND_CTX uint8_t
 #define RAND_CHOICE openssl_rand
 #elif defined(RLWE_RANDOMNESS_USE_DEV_URANDOM)
-#define RAND_CTX
+#define RAND_CTX int
 #define RAND_CHOICE dev_urandom
 #elif defined(RLWE_RANDOMNESS_USE_INSECURE_LIBC)
 #define RAND_CTX int

--- a/rlwe_rand.h
+++ b/rlwe_rand.h
@@ -12,19 +12,26 @@
 #if defined(RLWE_RANDOMNESS_USE_OPENSSL_AES)
 #include <openssl/evp.h>
 #define RAND_CTX EVP_CIPHER_CTX
+#define RAND_CHOICE openssl_aes
 #elif defined(RLWE_RANDOMNESS_USE_OPENSSL_RC4)
 #include <openssl/evp.h>
 #define RAND_CTX EVP_CIPHER_CTX
+#define RAND_CHOICE openssl_rc4
 #elif defined(RLWE_RANDOMNESS_USE_OPENSSL_RAND)
 #define RAND_CTX uint8_t
-#elif defined(RLWE_RANDOMNESS_USE_C_RANDOM_INSECURE)
-#define RAND_CTX uint8_t
+#define RAND_CHOICE openssl_rand
+#elif defined(RLWE_RANDOMNESS_USE_DEV_URANDOM)
+#define RAND_CTX
+#define RAND_CHOICE dev_urandom
+#elif defined(RLWE_RANDOMNESS_USE_INSECURE_LIBC)
+#define RAND_CTX int
+#define RAND_CHOICE insecure_libc
 #else
 #error "No randomness generation algorithm defined."
 #endif
 
-int RAND_CTX_init(RAND_CTX *rand_ctx);
-void RAND_CTX_cleanup(RAND_CTX *rand_ctx);
+int RAND_CHOICE_init(RAND_CTX *rand_ctx);
+void RAND_CHOICE_cleanup(RAND_CTX *rand_ctx);
 
 uint8_t  RANDOM8 (RAND_CTX *rand_ctx);
 uint32_t RANDOM32(RAND_CTX *rand_ctx);

--- a/rlwe_rand_dev_urandom.c
+++ b/rlwe_rand_dev_urandom.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "rlwe_rand.h"
+
+
+int dev_urandom_init(int *rand_ctx) {
+  int fd = open("/dev/urandom", O_RDONLY);
+  if (!fd) return 1;
+  *rand_ctx = fd;
+  return 0;
+}
+
+void dev_urandom_cleanup(int *rand_ctx) {
+  if (*rand_ctx)
+    close(*rand_ctx);
+}
+static void mkrandom(int *rand_ctx, uint8_t *buf, size_t len) {
+  read(*rand_ctx, buf, len);
+}
+
+uint8_t  RANDOM8(int *rand_ctx) {
+  uint8_t bit;
+  mkrandom(rand_ctx, &bit, 1);
+  return bit;
+}
+
+uint32_t RANDOM32(int *rand_ctx) {
+  uint32_t buf;
+  mkrandom(rand_ctx, (uint8_t *)&buf, 4);
+  return buf;
+}
+
+uint64_t RANDOM64(int *rand_ctx) {
+  uint64_t buf;
+  mkrandom(rand_ctx, (uint8_t *)&buf, 8);
+  return buf;
+}
+
+void RANDOM192(uint64_t r[3], int *rand_ctx) {
+  mkrandom(rand_ctx, (uint8_t *)r, 24);
+}
+
+void *(*volatile rlwe_memset_volatile)(void *, int, size_t) = memset;

--- a/rlwe_rand_dev_urandom.c
+++ b/rlwe_rand_dev_urandom.c
@@ -5,15 +5,14 @@
 #include <fcntl.h>
 #include "rlwe_rand.h"
 
-
-int dev_urandom_init(int *rand_ctx) {
+int RAND_CHOICE_init(int *rand_ctx) {
   int fd = open("/dev/urandom", O_RDONLY);
   if (!fd) return 1;
-  *rand_ctx = fd;
+  *rand_ctx = fd; 
   return 0;
 }
 
-void dev_urandom_cleanup(int *rand_ctx) {
+void RAND_CHOICE_cleanup(int *rand_ctx) {
   if (*rand_ctx)
     close(*rand_ctx);
 }
@@ -21,7 +20,7 @@ static void mkrandom(int *rand_ctx, uint8_t *buf, size_t len) {
   read(*rand_ctx, buf, len);
 }
 
-uint8_t  RANDOM8(int *rand_ctx) {
+uint8_t RANDOM8(int *rand_ctx) {
   uint8_t bit;
   mkrandom(rand_ctx, &bit, 1);
   return bit;

--- a/rlwe_rand_libc.c
+++ b/rlwe_rand_libc.c
@@ -5,11 +5,11 @@
 
 #include "rlwe_rand.h"
 
-int RAND_CTX_init(RAND_CTX *rand_ctx) {
+int RAND_CHOICE_init(RAND_CTX *rand_ctx) {
 	return 1;
 }
 
-void RAND_CTX_cleanup(RAND_CTX *rand_ctx) {
+void RAND_CHOICE_cleanup(RAND_CTX *rand_ctx) {
 }
 
 uint8_t  RANDOM8(RAND_CTX *rand_ctx) {

--- a/rlwe_rand_openssl_aes.c
+++ b/rlwe_rand_openssl_aes.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int RAND_CTX_init(RAND_CTX *rand_ctx) {
+int RAND_CHOICE_init(RAND_CTX *rand_ctx) {
 	int ret = 1;
 	unsigned char aes_key[16];
 	unsigned char aes_iv[16];
@@ -20,7 +20,7 @@ int RAND_CTX_init(RAND_CTX *rand_ctx) {
 	return ret;
 }
 
-void RAND_CTX_cleanup(RAND_CTX *rand_ctx) {
+void RAND_CHOICE_cleanup(RAND_CTX *rand_ctx) {
 	EVP_CIPHER_CTX_cleanup(rand_ctx);
 }
 

--- a/rlwe_rand_openssl_rand.c
+++ b/rlwe_rand_openssl_rand.c
@@ -6,11 +6,11 @@
 #include <stdio.h>
 #include <string.h>
 
-int RAND_CTX_init(RAND_CTX *rand_ctx) {
+int RAND_CHOICE_init(RAND_CTX *rand_ctx) {
 	return 1;
 }
 
-void RAND_CTX_cleanup(RAND_CTX *rand_ctx) {
+void RAND_CHOICE_cleanup(RAND_CTX *rand_ctx) {
 }
 
 uint8_t  RANDOM8(RAND_CTX *rand_ctx) {

--- a/rlwe_rand_openssl_rc4.c
+++ b/rlwe_rand_openssl_rc4.c
@@ -7,14 +7,14 @@
 #include <stdio.h>
 #include <string.h>
 
-int RAND_CTX_init(RAND_CTX *rand_ctx) {
+int RAND_CHOICE_init(RAND_CTX *rand_ctx) {
 	unsigned char rc4_key[16];
 	RAND_bytes(rc4_key, 16);
 	EVP_CIPHER_CTX_init(rand_ctx);
 	return EVP_EncryptInit_ex(rand_ctx, EVP_rc4(), NULL, rc4_key, NULL);
 }
 
-void RAND_CTX_cleanup(RAND_CTX *rand_ctx) {
+void RAND_CHOICE_cleanup(RAND_CTX *rand_ctx) {
 	EVP_CIPHER_CTX_cleanup(rand_ctx);
 }
 


### PR DESCRIPTION
I had to mess around with the macro magic for selecting the randomness backend in the process, but that's okay, it was insane to start with.

The Makefile is a bit lacking in flexibility. It would be nice for example to not try and link against libcrypto (which is no longer necessary now I've written this). I'm going to have a think about how it could be improved.

I can also confirm that it builds on FreeBSD 10.3 (latest), although FreeBSD's OpenSSL is somewhat alpha status, hence me writing this so as to avoid it.
